### PR TITLE
887 publication state

### DIFF
--- a/recipes/R-01_arcgis-hubs/R-01_arcgis-hubs-new.ipynb
+++ b/recipes/R-01_arcgis-hubs/R-01_arcgis-hubs-new.ipynb
@@ -44,7 +44,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 6,
    "id": "d0a88a21",
    "metadata": {},
    "outputs": [],
@@ -55,7 +55,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 7,
    "id": "043a301b",
    "metadata": {},
    "outputs": [],
@@ -79,7 +79,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 8,
    "id": "80a1f2f7",
    "metadata": {},
    "outputs": [],
@@ -101,7 +101,7 @@
     "    \"Spatial Coverage\",\n",
     "    \"Bounding Box\",\n",
     "    \"Format\",\n",
-    "    \"full_layer_description\",\n",
+    "    \"documentation_external\",\n",
     "    \"download\",\n",
     "    \"arcgis_dynamic_map_layer\",\n",
     "    \"arcgis_feature_layer\",\n",
@@ -117,12 +117,13 @@
     "    \"Accrual Method\",\n",
     "    \"Date Accessioned\",\n",
     "    \"Access Rights\",\n",
+    "    \"Publication State\"\n",
     "]"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 9,
    "id": "9ae8d590",
    "metadata": {},
    "outputs": [],
@@ -154,7 +155,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 10,
    "id": "f0f26afe",
    "metadata": {},
    "outputs": [],
@@ -195,7 +196,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 11,
    "id": "f7ec25b3",
    "metadata": {},
    "outputs": [],
@@ -365,7 +366,8 @@
     "            rights,\n",
     "            accrualMethod,\n",
     "            dateAccessioned, \n",
-    "            accessRights\n",
+    "            accessRights,\n",
+    "            publicationState\n",
     "        ]     \n",
     "\n",
     "        newItemDict[slug] = metadataList\n",
@@ -375,10 +377,19 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 12,
    "id": "5f8421ec",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "scanning  08b-42003 https://openac-alcogis.opendata.arcgis.com/api/feed/dcat-us/1.1.json\n",
+      "scanning  04b-24003 https://maps.aacounty.org/api/feed/dcat-us/1.1.json\n"
+     ]
+    }
+   ],
    "source": [
     "# Main execution\n",
     "allRecords = []\n",
@@ -396,6 +407,7 @@
     "        accrualMethod = \"ArcGIS Hub\"\n",
     "        dateAccessioned = time.strftime('%Y-%m-%d')\n",
     "        accessRights = \"Public\"\n",
+    "        publicationState = \"published\"\n",
     "        language = \"eng\"\n",
     "        displayNote = (\"This dataset was automatically cataloged from the provider's ArcGIS Hub. \"\n",
     "                       \"In some cases, information shown here may be incorrect or out-of-date. \"\n",
@@ -419,7 +431,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 13,
    "id": "4a2eb7f8",
    "metadata": {},
    "outputs": [],
@@ -448,7 +460,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 15,
    "id": "4790264d",
    "metadata": {},
    "outputs": [],
@@ -502,14 +514,22 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 17,
    "id": "59bd10b7",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "CSV files have been created successfully.\n"
+     ]
+    }
+   ],
    "source": [
     "# Create the first CSV (all fields except links)\n",
     "# Updated fields for links\n",
-    "link_fields = ['full_layer_description', 'download', 'arcgis_dynamic_map_layer', 'arcgis_feature_layer', 'arcgis_image_map_layer', 'arcgis_tiled_map_layer']\n",
+    "link_fields = ['documentation_external', 'download', 'arcgis_dynamic_map_layer', 'arcgis_feature_layer', 'arcgis_image_map_layer', 'arcgis_tiled_map_layer']\n",
     "df_first_csv = df.drop(columns=link_fields)\n",
     "df_first_csv.to_csv(f'{ActionDate}_ArcHubs-metadata.csv', index=False)\n",
     "\n",
@@ -552,7 +572,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.4"
+   "version": "3.10.12"
   }
  },
  "nbformat": 4,

--- a/recipes/R-01_arcgis-hubs/R-01_arcgis-hubs-new.ipynb
+++ b/recipes/R-01_arcgis-hubs/R-01_arcgis-hubs-new.ipynb
@@ -44,7 +44,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": null,
    "id": "d0a88a21",
    "metadata": {},
    "outputs": [],
@@ -55,7 +55,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": null,
    "id": "043a301b",
    "metadata": {},
    "outputs": [],
@@ -79,7 +79,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": null,
    "id": "80a1f2f7",
    "metadata": {},
    "outputs": [],
@@ -123,7 +123,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": null,
    "id": "9ae8d590",
    "metadata": {},
    "outputs": [],
@@ -155,7 +155,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": null,
    "id": "f0f26afe",
    "metadata": {},
    "outputs": [],
@@ -196,7 +196,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": null,
    "id": "f7ec25b3",
    "metadata": {},
    "outputs": [],
@@ -377,19 +377,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": null,
    "id": "5f8421ec",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "scanning  08b-42003 https://openac-alcogis.opendata.arcgis.com/api/feed/dcat-us/1.1.json\n",
-      "scanning  04b-24003 https://maps.aacounty.org/api/feed/dcat-us/1.1.json\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# Main execution\n",
     "allRecords = []\n",
@@ -431,7 +422,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": null,
    "id": "4a2eb7f8",
    "metadata": {},
    "outputs": [],
@@ -460,7 +451,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": null,
    "id": "4790264d",
    "metadata": {},
    "outputs": [],
@@ -514,18 +505,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": null,
    "id": "59bd10b7",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "CSV files have been created successfully.\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# Create the first CSV (all fields except links)\n",
     "# Updated fields for links\n",


### PR DESCRIPTION
This adds a the Publication State field into the CSVs for the ArcGIS Hubs.

It also changes the reference key for landing (information) pages from `full_layer_description` (now a deprecated key) to `documentation_external`